### PR TITLE
Theme-name acquisition improvement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ django-cms-themes
 =================
 A django app that lets you load theme packs that are bundled templates, and select which theme a site should use.
 
-Dependancies
+Dependencies
 ============
 
 - django (tested with 1.3)

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To get started simply install using ``pip``:
 ::
     pip install django-cms-themes
 
-Add ``cms_themes`` to your installed apps and ``syncdb`` (or migrate, if you have south installed).
+Add ``'cms_themes',`` to your installed apps and ``syncdb`` (or migrate, if you have south installed).
 
 Your installed apps should look something like this:
 ::

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ Your installed apps should look something like this:
 	    'cms_themes',
 	)
 	
-Make sure that you have a setting in your settings file called PROJECT_DIR that points to the root of your project, i.e. PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+You should have a setting in your settings file called PROJECT_DIR that points to the root of your project, i.e. ``PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))``
+If not, it will be assumed that your themes will live just beneath the ``MEDIA_ROOT``.
 
 Usage
 =============

--- a/cms_themes/__init__.py
+++ b/cms_themes/__init__.py
@@ -43,13 +43,12 @@ def set_themes():
         return
 
     theme_templates = []
-    theme_static = []
     for theme_dir in os.listdir(settings.THEMES_DIR):
         if theme_dir in themes:
             theme_full_path = os.path.join(settings.THEMES_DIR, theme_dir)
             if os.path.isdir(theme_full_path) and 'templates' in os.listdir(theme_full_path):
                 template_path = os.path.join(theme_full_path, 'templates')
-                setattr(settings, 'TEMPLATE_DIRS', (template_path,) + settings.DEFAULT_TEMPLATE_DIRS)
+                setattr(settings, 'TEMPLATE_DIRS', [template_path,] + settings.DEFAULT_TEMPLATE_DIRS)
                 for template in os.listdir(template_path):
                     template_display = '%s (%s)' % (template.replace('_', ' ').title().split('.')[0], theme_dir)
                     theme_templates.append((template, template_display))

--- a/cms_themes/__init__.py
+++ b/cms_themes/__init__.py
@@ -5,17 +5,22 @@ import os
 
 def init_themes():
     if not hasattr(settings, 'THEMES_DIR'):
-        THEMES_DIR = os.path.join(settings.PROJECT_DIR, 'themes')
+        if hasattr(settings, 'PROJECT_DIR'):
+            THEMES_DIR = os.path.join(settings.PROJECT_DIR, 'themes')
+        elif hasattr(settings, 'PROJECT_HOME'):
+            THEMES_DIR = os.path.join(settings.PROJECT_HOME, 'themes')
+        else:
+            THEMES_DIR = os.path.join(settings.MEDIA_ROOT, 'themes')
         if not os.path.exists(THEMES_DIR):
             os.makedirs(THEMES_DIR)
         settings.STATICFILES_DIRS = (
-            ('themes', os.path.join(settings.PROJECT_DIR, "themes")),
+            ('themes', THEMES_DIR),
         ) + settings.STATICFILES_DIRS
         setattr(settings, 'THEMES_DIR', THEMES_DIR)
     if not hasattr(settings, 'DEFAULT_CMS_TEMPLATES'):
         setattr(settings, 'DEFAULT_CMS_TEMPLATES', settings.CMS_TEMPLATES)
     if settings.THEMES_DIR not in settings.TEMPLATE_DIRS:
-        settings.TEMPLATE_DIRS = settings.TEMPLATE_DIRS + (settings.THEMES_DIR,)
+        settings.TEMPLATE_DIRS = list(settings.TEMPLATE_DIRS) + [settings.THEMES_DIR,]
     if not hasattr(settings, 'DEFAULT_TEMPLATE_DIRS'):
         setattr(settings, 'DEFAULT_TEMPLATE_DIRS', settings.TEMPLATE_DIRS)
     if not hasattr(settings, 'DEFAULT_STATICFILES_DIRS'):
@@ -49,8 +54,8 @@ def set_themes():
                     template_display = '%s (%s)' % (template.replace('_', ' ').title().split('.')[0], theme_dir)
                     theme_templates.append((template, template_display))
 
-    setattr(settings, 'CMS_TEMPLATES', tuple(theme_templates) + settings.DEFAULT_CMS_TEMPLATES)
-    setattr(settings, 'STATICFILES_DIRS', (settings.THEMES_DIR,) + settings.DEFAULT_STATICFILES_DIRS)
+    setattr(settings, 'CMS_TEMPLATES', list(theme_templates) + list(settings.DEFAULT_CMS_TEMPLATES))
+    setattr(settings, 'STATICFILES_DIRS', [settings.THEMES_DIR] + list(settings.DEFAULT_STATICFILES_DIRS))
 
 try:
     from django.conf import settings

--- a/cms_themes/admin.py
+++ b/cms_themes/admin.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext, ugettext_lazy as _
 from django.db import models
 
 class ThemeAdmin(admin.ModelAdmin):
-    list_display = ('id','name',)
+    list_display = ('id','name','theme_file',)
     list_display_links = ('id','name',)
     list_filter = ('name',)
     filter_horizontal = ('sites',)

--- a/cms_themes/models.py
+++ b/cms_themes/models.py
@@ -17,7 +17,7 @@ class Theme(models.Model):
     def save(self, *args, **kwargs):
         if not self.id:
             f = tarfile.open(fileobj=self.theme_file, mode='r:gz')
-            self.name = f.getnames()[-1]
+            self.name = os.path.commonprefix(f.getnames())
             f.extractall(settings.THEMES_DIR)
 
         super(Theme, self).save(*args, **kwargs)


### PR DESCRIPTION
I noticed that if my theme was not ordered correctly in the tarball, the theme would not work correctly due to the naming being different than the file-space.  Assuming that every theme will be single-directory-root archive, we can just grab the actual file path from inside the archive instead.  This will also allow version numbers in the filename that will not interfere with the extracted filesystem-to-name convention.
