### PR TITLE
Fixed exception syntax for python 2.6+ & 3.x

### DIFF
--- a/cms_themes/__init__.py
+++ b/cms_themes/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 VERSION = (1,0,11)
 __version__ = "1.0.11"
 import random
@@ -66,5 +67,5 @@ try:
     init_themes()
     set_themes()
 except Exception as ex:
-    print 'An error occured setting up the themes: %s' % ex
+    print('An error occured setting up the themes: %s' % ex)
 

--- a/cms_themes/__init__.py
+++ b/cms_themes/__init__.py
@@ -65,6 +65,6 @@ try:
 
     init_themes()
     set_themes()
-except Exception, ex:
+except Exception as ex:
     print 'An error occured setting up the themes: %s' % ex
 

--- a/cms_themes/models.py
+++ b/cms_themes/models.py
@@ -1,5 +1,5 @@
 import tarfile
-import StringIO
+from io import StringIO
 import shutil
 import os
 

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
 from django.conf.urls.defaults import *
 from django.contrib import admin
 from django.conf import settings
+
 
 admin.autodiscover()
 
@@ -9,7 +11,7 @@ urlpatterns = patterns('',
     url(r'^', include('cms.urls')),
 )
 
-print settings.STATIC_ROOT
+print(settings.STATIC_ROOT)
 if settings.DEBUG:
     urlpatterns = patterns('',
     url(r'^media/(?P<path>.*)$', 'django.views.static.serve',


### PR DESCRIPTION
Fixes the syntax of an exception handle so it will install under pip3
